### PR TITLE
Add ConvertOptions and compile Regex for performance

### DIFF
--- a/src/Marques.EFCore.SnakeCase/ToSnakeCase.cs
+++ b/src/Marques.EFCore.SnakeCase/ToSnakeCase.cs
@@ -6,41 +6,65 @@ namespace Marques.EFCore.SnakeCase
 {
     public static class SnakeToCamelCase
     {
+        [Flags]
+        public enum ConvertOptions 
+        {
+            All = 2 << 0,
+            Tables = 2 << 1,
+            Properties = 2 << 2,
+            Keys = 2 << 3,
+            ForeignKeys = 2 << 4,
+            Indexes = 2 << 5,
+        };
+        private static Regex leadingUndescoreRegex = new Regex(@"^_", RegexOptions.Compiled);
+        private static Regex camelCaseRegex = new Regex(@"([a-z0-9])([A-Z])", RegexOptions.Compiled);
+        
         public static string ToSnakeCase(this string input)
         {
             if (string.IsNullOrEmpty(input)) { return input; }
 
-            var noLeadingUndescore = Regex.Replace(input, @"^_", "");
-            return Regex.Replace(noLeadingUndescore, @"([a-z0-9])([A-Z])", "$1_$2").ToLower();
+            var noLeadingUndescore = leadingUndescoreRegex.Replace(input, "");
+            return camelCaseRegex.Replace(noLeadingUndescore, "$1_$2").ToLower();
         }
 
-        public static void ToSnakeCase(this ModelBuilder modelBuilder)
+        public static void ToSnakeCase(this ModelBuilder modelBuilder, ConvertOptions options = ConvertOptions.All)
         {
+            bool convertAll = (options & ConvertOptions.All) == ConvertOptions.All;
+            bool convertTables = (options & ConvertOptions.Tables) == ConvertOptions.Tables;
+            bool convertProperties = (options & ConvertOptions.Properties) == ConvertOptions.Properties;
+            bool convertKeys = (options & ConvertOptions.Keys) == ConvertOptions.Keys;
+            bool convertForeignKeys = (options & ConvertOptions.ForeignKeys) == ConvertOptions.ForeignKeys;
+            bool convertIndexes = (options & ConvertOptions.Indexes) == ConvertOptions.Indexes;
+
             foreach (var entity in modelBuilder.Model.GetEntityTypes())
             {
-                entity.SetTableName(entity.GetTableName().ToSnakeCase());
+                if (convertAll || convertTables)
+                    entity.SetTableName(entity.GetTableName().ToSnakeCase());
 
-                foreach (var property in entity.GetProperties())
-                {
-                    property.SetColumnName(property.GetColumnName().ToSnakeCase());
-                }
+                if (convertAll || convertProperties)
+                    foreach (var property in entity.GetProperties())
+                    {
+                        property.SetColumnName(property.GetColumnName().ToSnakeCase());
+                    }
 
-                foreach (var key in entity.GetKeys())
-                {
-                    key.SetName(key.GetName().ToSnakeCase());
-                }
+                if (convertAll || convertKeys)
+                    foreach (var key in entity.GetKeys())
+                    {
+                        key.SetName(key.GetName().ToSnakeCase());
+                    }
 
-                foreach (var key in entity.GetForeignKeys())
-                {
-                    key.SetConstraintName(key.GetConstraintName().ToSnakeCase());
-                }
+                if (convertAll || convertForeignKeys)
+                    foreach (var key in entity.GetForeignKeys())
+                    {
+                        key.SetConstraintName(key.GetConstraintName().ToSnakeCase());
+                    }
 
-                foreach (var index in entity.GetIndexes())
-                {
-                    index.SetName(index.GetName().ToSnakeCase());
-                }
+                if (convertAll || convertIndexes)
+                    foreach (var index in entity.GetIndexes())
+                    {
+                        index.SetName(index.GetName().ToSnakeCase());
+                    }
             }
-
         }
 
     }


### PR DESCRIPTION
Can I suggest the following edits to make the code more flexible? This hasn't been properly tested but should work fine. The default behaviour of the library is the same as before (`ConvertOptions options = ConvertOptions.All`).

Usage:
```csharp
builder.ToSnakeCase(ConvertOptions.Tables | ConvertOptions.Properties);
```