### PR TITLE
Changed behavior of all-caps substring to cleave prior to last character

### DIFF
--- a/src/Marques.EFCore.SnakeCase/ToSnakeCase.cs
+++ b/src/Marques.EFCore.SnakeCase/ToSnakeCase.cs
@@ -11,7 +11,7 @@ namespace Marques.EFCore.SnakeCase
             if (string.IsNullOrEmpty(input)) { return input; }
 
             var noLeadingUndescore = Regex.Replace(input, @"^_", "");
-            return Regex.Replace(noLeadingUndescore, @"([a-z0-9])([A-Z])", "$1_$2").ToLower();
+            return Regex.Replace(noLeadingUndescore, @"(?:(?<l>[a-z0-9])(?<r>[A-Z])|(?<l>[A-Z])(?<r>[A-Z][a-z0-9]))", "${l}_${r}").ToLower();
         }
 
         public static void ToSnakeCase(this ModelBuilder modelBuilder)

--- a/tests/SnakeCaseTests/FormatTests.cs
+++ b/tests/SnakeCaseTests/FormatTests.cs
@@ -12,7 +12,7 @@ namespace SnakeCaseTests
         [InlineData("_Person_Log", "person_log")]
         [InlineData("Person_1Log", "person_1_log")]
         [InlineData("Person1Log", "person1_log")]
-        [InlineData("PersonLOGFile", "person_logfile")]
+        [InlineData("PersonLOGFile", "person_log_file")]
         [InlineData("PersonCodeId", "person_code_id")]
         [InlineData("PersonAddress_", "person_address_")]
         public void TestFramatNames(string given, string expcted)


### PR DESCRIPTION
I think it's more conventional for sub-strings of upper-case letters to be isolated between '_' characters in snake-case rather than being grouped with the following lower-case letters, so I modified the regex pattern accordingly.

The new behaviour would act as follows when upper-case sub-strings begin the input string or are contained within it.  All other conventions have been maintained.

Input|Becomes | Instead Of
----- | ----- | -----
PersonLOGFile | person_log_file | person_logfile
UPCCode | upc_code | upccode
SpecifyCORSPolicy | specify_cors_policy | specify_corspolicy
