### PR TITLE
Cleave all-caps substring prior to last character rather than not at all

### DIFF
--- a/src/Marques.EFCore.SnakeCase/ToSnakeCase.cs
+++ b/src/Marques.EFCore.SnakeCase/ToSnakeCase.cs
@@ -18,14 +18,14 @@ namespace Marques.EFCore.SnakeCase
             Indexes = 2 << 5,
         };
         private static Regex leadingUndescoreRegex = new Regex(@"^_", RegexOptions.Compiled);
-        private static Regex camelCaseRegex = new Regex(@"([a-z0-9])([A-Z])", RegexOptions.Compiled);
+        private static Regex camelCaseRegex = new Regex(@"(?:(?<l>[a-z0-9])(?<r>[A-Z])|(?<l>[A-Z])(?<r>[A-Z][a-z0-9]))", RegexOptions.Compiled);
         
         public static string ToSnakeCase(this string input)
         {
             if (string.IsNullOrEmpty(input)) { return input; }
 
             var noLeadingUndescore = leadingUndescoreRegex.Replace(input, "");
-            return camelCaseRegex.Replace(noLeadingUndescore, "$1_$2").ToLower();
+            return camelCaseRegex.Replace(noLeadingUndescore, "${l}_${r}").ToLower();
         }
 
         public static void ToSnakeCase(this ModelBuilder modelBuilder, ConvertOptions options = ConvertOptions.All)

--- a/tests/SnakeCaseTests/FormatTests.cs
+++ b/tests/SnakeCaseTests/FormatTests.cs
@@ -12,10 +12,10 @@ namespace SnakeCaseTests
         [InlineData("_Person_Log", "person_log")]
         [InlineData("Person_1Log", "person_1_log")]
         [InlineData("Person1Log", "person1_log")]
-        [InlineData("PersonLOGFile", "person_logfile")]
+        [InlineData("PersonLOGFile", "person_log_file")]
         [InlineData("PersonCodeId", "person_code_id")]
         [InlineData("PersonAddress_", "person_address_")]
-        public void TestFramatNames(string given, string expcted)
+        public void TestFormatNames(string given, string expcted)
         {
             given.ToSnakeCase().ShouldBe(expcted);
         }


### PR DESCRIPTION
This corrects what I think is a regression that was merged in f5f2b20e to master on 2020-01-14.